### PR TITLE
Add BERT+MLP stance classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # StanceAnalisys
 Stance Analisys and Narrative identification
+
+## MLP Stance Classifier
+A simple multilayer perceptron (`mlp_stance_classifier.py`) trains on
+additional numeric fields from `cleaned_stance_dataset_enriched.csv` to
+predict the `stance` label.
+
+```bash
+pip install -r requirements.txt
+python mlp_stance_classifier.py
+```
+
+## BERT + MLP Classifier
+`bert_mlp_stance_classifier.py` combines BERT text embeddings with the
+same numeric features and trains an MLP on the concatenated vectors.
+This allows leveraging contextual information from the post while still
+using quantitative metadata like emoji counts or sentiment.
+
+```bash
+python bert_mlp_stance_classifier.py
+```

--- a/bert_mlp_stance_classifier.py
+++ b/bert_mlp_stance_classifier.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.neural_network import MLPClassifier
+from sklearn.metrics import classification_report, accuracy_score
+from transformers import AutoTokenizer, AutoModel
+import torch
+from tqdm import tqdm
+
+
+MODEL_NAME = "dbmdz/bert-base-italian-uncased"
+
+
+def compute_embeddings(texts, tokenizer, model, batch_size=16):
+    model.eval()
+    embeddings = []
+    for i in tqdm(range(0, len(texts), batch_size)):
+        batch = texts[i:i + batch_size]
+        inputs = tokenizer(batch, padding=True, truncation=True, max_length=128, return_tensors="pt")
+        with torch.no_grad():
+            outputs = model(**inputs)
+            cls = outputs.last_hidden_state[:, 0, :]
+            embeddings.append(cls)
+    return torch.cat(embeddings).numpy()
+
+
+def main():
+    df = pd.read_csv("cleaned_stance_dataset_enriched.csv")
+    feature_cols = [
+        "EMOJI_COUNT",
+        "LINK present",
+        "NUM_WORDS",
+        "NUM_UPPERCASE",
+        "bio_sentiment",
+    ]
+    df = df[["content", "stance"] + feature_cols].fillna(0)
+
+    texts = df["content"].astype(str).tolist()
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model = AutoModel.from_pretrained(MODEL_NAME)
+
+    print("Computing BERT embeddings...")
+    text_embeddings = compute_embeddings(texts, tokenizer, model)
+
+    numeric_features = df[feature_cols].values
+    X = np.hstack([text_embeddings, numeric_features])
+    y = df["stance"].values
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(X_train)
+    X_test = scaler.transform(X_test)
+
+    clf = MLPClassifier(hidden_layer_sizes=(256, 64), max_iter=20, random_state=42)
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_test)
+    print("Accuracy:", accuracy_score(y_test, preds))
+    print(classification_report(y_test, preds))
+
+
+if __name__ == "__main__":
+    main()

--- a/mlp_stance_classifier.py
+++ b/mlp_stance_classifier.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.neural_network import MLPClassifier
+from sklearn.metrics import classification_report, accuracy_score
+
+
+def main():
+    df = pd.read_csv('cleaned_stance_dataset_enriched.csv')
+    features = ['EMOJI_COUNT', 'LINK present', 'NUM_WORDS', 'NUM_UPPERCASE', 'bio_sentiment']
+    X = df[features].fillna(0)
+    y = df['stance']
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
+
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(X_train)
+    X_test = scaler.transform(X_test)
+
+    clf = MLPClassifier(hidden_layer_sizes=(64, 32), max_iter=200, random_state=42)
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_test)
+    print('Accuracy:', accuracy_score(y_test, preds))
+    print(classification_report(y_test, preds))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `bert_mlp_stance_classifier.py` to combine BERT embeddings with numeric features
- document new script in README

## Testing
- `python -m py_compile bert_mlp_stance_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_68406546a658832483812c5080ec16c4